### PR TITLE
small fix to is_pe so it will work after seeking elsewhere in the file

### DIFF
--- a/lib/libpe/pe.c
+++ b/lib/libpe/pe.c
@@ -384,6 +384,7 @@ bool is_pe(PE_FILE *pe)
 	if (pe->handle == NULL)
 		return false;
 
+	rewind(pe->handle);	
 	if (!fread(&header, sizeof(WORD), 1, pe->handle))
 		return false;
 


### PR DESCRIPTION
For example, after calling pe_get_optional is_pe returns false.

Old behavior:
pe_init -> true
is_pe -> true
pe_get_optional -> true
is_pe -> false

Correct behavior:
pe_init -> true
is_pe -> true
pe_get_optional -> true
is_pe -> true
