### PR TITLE
Portability fix: Ship our own copy of strlcat() from the OpenBSD implementation.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -30,18 +30,15 @@ MANDIR = /usr/share/man/man1
 all: $(PROGS)
 
 pesec: LDFLAGS += -lcrypto
+pesec: compat/strlcat.c
 
 pestr: CPPFLAGS += -D_GNU_SOURCE=1
 pestr: LDFLAGS += -lpcre
-pestr: pestr.c
-
-peres: peres.c
 
 pehash: LDFLAGS += -lssl -lcrypto
-pehash: pehash.c
 
 pedis: CFLAGS += -I$(LIBUDIS86)
-pedis: pedis.c $(LIBUDIS86)/libudis86/*.c
+pedis: $(LIBUDIS86)/libudis86/*.c
 
 pescan: LDFLAGS += -lm
 

--- a/src/compat/strlcat.c
+++ b/src/compat/strlcat.c
@@ -1,0 +1,54 @@
+/*	$OpenBSD: strlcat.c,v 1.13 2005/08/08 08:05:37 espie Exp $	*/
+
+/*
+ * Copyright (c) 1998 Todd C. Miller <Todd.Miller@courtesan.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <string.h>
+
+/*
+ * Appends src to string dst of size siz (unlike strncat, siz is the
+ * full size of dst, not space left).  At most siz-1 characters
+ * will be copied.  Always NUL terminates (unless siz <= strlen(dst)).
+ * Returns strlen(src) + MIN(siz, strlen(initial dst)).
+ * If retval >= siz, truncation occurred.
+ */
+size_t
+bsd_strlcat(char *dst, const char *src, size_t siz)
+{
+	char *d = dst;
+	const char *s = src;
+	size_t n = siz;
+	size_t dlen;
+
+	/* Find the end of dst and adjust bytes left but don't go past end */
+	while (n-- != 0 && *d != '\0')
+		d++;
+	dlen = d - dst;
+	n = siz - dlen;
+
+	if (n == 0)
+		return(dlen + strlen(s));
+	while (*s != '\0') {
+		if (n != 1) {
+			*d++ = *s;
+			n--;
+		}
+		s++;
+	}
+	*d = '\0';
+
+	return(dlen + (s - src));	/* count does not include NUL */
+}

--- a/src/compat/strlcat.h
+++ b/src/compat/strlcat.h
@@ -1,0 +1,8 @@
+#ifndef STRLCAT_H
+#define STRLCAT_H
+
+#include <stddef.h>
+
+size_t bsd_strlcat(char *dst, const char *src, size_t siz);
+
+#endif

--- a/src/pesec.c
+++ b/src/pesec.c
@@ -20,11 +20,11 @@
 */
 
 #include "pesec.h"
-#include <stddef.h>
 #include <string.h>
 #include <openssl/err.h>
 #include <openssl/pem.h>
 #include <openssl/x509.h>
+#include "compat/strlcat.h"
 
 typedef enum {
 	CERT_FORMAT_TEXT = 1,
@@ -344,10 +344,10 @@ static void parse_certificates(const options_t *options, PE_FILE *pe)
 
 		snprintf(value, MAX_MSG, "0x%x", cert->wCertificateType);
 		switch (cert->wCertificateType) {
-			default: strlcat(value, " (UNKNOWN)", MAX_MSG); break;
-			case WIN_CERT_TYPE_X509: strlcat(value, " (X509)", MAX_MSG); break;
-			case WIN_CERT_TYPE_PKCS_SIGNED_DATA: strlcat(value, " (PKCS_SIGNED_DATA)", MAX_MSG); break;
-			case WIN_CERT_TYPE_TS_STACK_SIGNED: strlcat(value, " (TS_STACK_SIGNED)", MAX_MSG); break;
+			default: bsd_strlcat(value, " (UNKNOWN)", MAX_MSG); break;
+			case WIN_CERT_TYPE_X509: bsd_strlcat(value, " (X509)", MAX_MSG); break;
+			case WIN_CERT_TYPE_PKCS_SIGNED_DATA: bsd_strlcat(value, " (PKCS_SIGNED_DATA)", MAX_MSG); break;
+			case WIN_CERT_TYPE_TS_STACK_SIGNED: bsd_strlcat(value, " (TS_STACK_SIGNED)", MAX_MSG); break;
 		}
 		output("Type", value);
 


### PR DESCRIPTION
Fix a portability issue regarding strlcat(). We now ship our own copy
of strlcat() from the OpenBSD implementation.
I renamed it to bsd_strlcat() with the intent of avoiding a couple of
preprocessor directives. To avoid other problems, always use our own
copy instead of the system's native.

A bit of history:
&nbsp;&nbsp;The strlcpy() and strlcat() functions first appeared in
&nbsp;&nbsp;OpenBSD 2.4, and made their appearance in FreeBSD 3.3.
&nbsp;&nbsp;They are not defined by ANSI/ISO C nor POSIX, and are not present in
&nbsp;&nbsp;GNU/Linux, but they're present in the Standard C Library (libc) of
&nbsp;&nbsp;all BSD-based systems, and some UNIX variants. Solaris ships it's
&nbsp;&nbsp;own version with slightly different semantics (see [1]) when `siz`
&nbsp;&nbsp;is 0, or when there are NIL characters in `dst`.

See [2] for a detailed explanation.

[1] http://goo.gl/oa6pJ
[2] http://goo.gl/4uKQg
