### PR TITLE
Attempt to automatically load plugins and initialize subsystems.

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -19,8 +19,7 @@
 	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef COMMON_H
-#define COMMON_H 1
+#pragma once
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -50,4 +49,22 @@
 
 void *malloc_s(size_t size);
 
-#endif
+#if defined(__GNUC__)
+#  define PEV_INITIALIZE()
+#  define PEV_FINALIZE()
+#else // if defined(__GNUC__)
+#  define PEV_INITIALIZE() \
+		do { \
+			int ret = plugins_load_all(); \
+			if (ret < 0) { \
+				exit(EXIT_FAILURE); \
+			} \
+			output_init(); /* Requires plugin for text output. */ \
+		} while (0)
+
+#  define PEV_FINALIZE() \
+		do { \
+			output_term(); \
+			plugins_unload_all(); \
+		} while (0)
+#endif // if defined(__GNUC__)

--- a/include/compat/gnuc_attr_ctor_prios.h
+++ b/include/compat/gnuc_attr_ctor_prios.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#if defined(__GNUC__)
+
+#define ATTR_CTOR_PRIO_BASE		1000
+#define ATTR_CTOR_PRIO_PLUGINS	ATTR_CTOR_PRIO_BASE + 1
+#define ATTR_CTOR_PRIO_OUTPUT	ATTR_CTOR_PRIO_BASE + 2
+
+#endif // if defined(__GNUC__)

--- a/include/compat/strlcat.h
+++ b/include/compat/strlcat.h
@@ -1,8 +1,5 @@
-#ifndef STRLCAT_H
-#define STRLCAT_H
+#pragma once
 
 #include <stddef.h>
 
 size_t bsd_strlcat(char *dst, const char *src, size_t siz);
-
-#endif

--- a/include/output.h
+++ b/include/output.h
@@ -19,8 +19,7 @@
 	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef OUTPUT_H
-#define OUTPUT_H
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -82,6 +81,4 @@ void output_keyval(const char *key, const char *value);
 
 #ifdef __cplusplus
 } //extern "C"
-#endif
-
 #endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -89,13 +89,17 @@ pescan: LDFLAGS += -lm
 # Generic rule matching binary names and sources
 
 %: %.c
+	@# NOTE: The order of translation units here is EXTREMELY IMPORTANT.
+	@#       If you're compiling with gcc, you don't have to worry, but other
+	@#		compilers like clang (default on Mac OS X) do not respect the
+	@#		priorities defined in `__attribute__((constructor (priority)))`.
 	$(CC) $(CFLAGS) $(CPPFLAGS) \
 		compat/strlcat.c \
 		dylib.c \
 		malloc_s.c \
+		plugins.c \
 		output_plugin.c \
 		output.c \
-		plugins.c \
 		$^ -o $@ $(LDFLAGS)
 
 install: installdirs

--- a/src/ofs2rva.c
+++ b/src/ofs2rva.c
@@ -69,6 +69,8 @@ static void parse_options(int argc, char *argv[])
 
 int main(int argc, char *argv[])
 {
+	//PEV_INITIALIZE();
+
 	if (argc != 3) {
 		usage();
 		return EXIT_FAILURE;
@@ -102,6 +104,8 @@ int main(int argc, char *argv[])
 
 	// libera a memoria
 	pe_unload(&ctx);
+
+	//PEV_FINALIZE();
 
 	return EXIT_SUCCESS;
 }

--- a/src/output.c
+++ b/src/output.c
@@ -328,3 +328,21 @@ void output_keyval(const char *key, const char *value) {
 	if (g_format != NULL)
 		g_format->output_fn(g_format, type, doc_level + scope_level, key, value);
 }
+
+#include "compat/gnuc_attr_ctor_prios.h"
+
+#if defined(__GNUC__)
+__attribute__((constructor (ATTR_CTOR_PRIO_OUTPUT)))
+#endif
+static void initializer(void) {
+	//printf("output\n");
+	output_init();
+}
+
+#if defined(__GNUC__)
+__attribute__((destructor (ATTR_CTOR_PRIO_OUTPUT)))
+#endif
+static void finalizer(void) {
+	//printf("~output\n");
+	output_term();
+}

--- a/src/pedis.c
+++ b/src/pedis.c
@@ -283,17 +283,13 @@ static void disassemble_offset(pe_ctx_t *ctx, const options_t *options, ud_t *ud
 
 int main(int argc, char *argv[])
 {
-	int ret = plugins_load_all();
-	if (ret < 0) {
-		exit(EXIT_FAILURE);
-	}
+	PEV_INITIALIZE();
 
 	if (argc < 2) {
 		usage();
 		exit(EXIT_FAILURE);
 	}
 
-	output_init();
 	output_set_cmdline(argc, argv);
 
 	options_t *options = parse_options(argc, argv); // opcoes
@@ -381,9 +377,7 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-	output_term();
-
-	plugins_unload_all();
+	PEV_FINALIZE();
 
 	return EXIT_SUCCESS;
 }

--- a/src/pehash.c
+++ b/src/pehash.c
@@ -230,17 +230,13 @@ static void print_basic_hash(const unsigned char *data, size_t size)
 
 int main(int argc, char *argv[])
 {
-	int ret = plugins_load_all();
-	if (ret < 0) {
-		exit(EXIT_FAILURE);
-	}
+	PEV_INITIALIZE();
 
 	if (argc < 2) {
 		usage();
 		return EXIT_FAILURE;
 	}
 
-	output_init();
 	output_set_cmdline(argc, argv);
 
 	OpenSSL_add_all_digests();
@@ -407,9 +403,7 @@ int main(int argc, char *argv[])
 
 	EVP_cleanup(); // Clean OpenSSL_add_all_digests.
 
-	output_term();
-
-	plugins_unload_all();
+	PEV_FINALIZE();
 
 	return EXIT_SUCCESS;
 }

--- a/src/pepack.c
+++ b/src/pepack.c
@@ -236,17 +236,13 @@ static bool compare_signature(const unsigned char *data, uint64_t ep_offset, FIL
 
 int main(int argc, char *argv[])
 {
-	int ret = plugins_load_all();
-	if (ret < 0) {
-		exit(EXIT_FAILURE);
-	}
+	PEV_INITIALIZE();
 
 	if (argc < 2) {
 		usage();
 		exit(EXIT_FAILURE);
 	}
 
-	output_init();
 	output_set_cmdline(argc, argv);
 
 	options_t *options = parse_options(argc, argv); // opcoes
@@ -311,9 +307,7 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-	output_term();
-
-	plugins_unload_all();
+	PEV_FINALIZE();
 
 	return EXIT_SUCCESS;
 }

--- a/src/peres.c
+++ b/src/peres.c
@@ -684,12 +684,13 @@ _error:
 
 int main(int argc, char **argv)
 {
+	PEV_INITIALIZE();
+
 	if (argc < 3) {
 		usage();
 		exit(EXIT_FAILURE);
 	}
 
-	output_init();
 	output_set_cmdline(argc, argv);
 
 	options_t *options = parse_options(argc, argv); // opcoes
@@ -747,7 +748,7 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
-	output_term();
+	PEV_FINALIZE();
 
 	return EXIT_SUCCESS;
 }

--- a/src/pescan.c
+++ b/src/pescan.c
@@ -462,17 +462,13 @@ static int8_t cpl_analysis(pe_ctx_t *ctx)
 
 int main(int argc, char *argv[])
 {
-	int ret = plugins_load_all();
-	if (ret < 0) {
-		exit(EXIT_FAILURE);
-	}
+	PEV_INITIALIZE();
 
 	if (argc < 2) {
 		usage();
 		return EXIT_FAILURE;
 	}
 
-	output_init();
 	output_set_cmdline(argc, argv);
 
 	options_t *options = parse_options(argc, argv); // opcoes
@@ -606,9 +602,7 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-	output_term();
-
-	plugins_unload_all();
+	PEV_FINALIZE();
 
 	return EXIT_SUCCESS;
 }

--- a/src/pesec.c
+++ b/src/pesec.c
@@ -386,17 +386,13 @@ static void parse_certificates(const options_t *options, pe_ctx_t *ctx)
 
 int main(int argc, char *argv[])
 {
-	int ret = plugins_load_all();
-	if (ret < 0) {
-		exit(EXIT_FAILURE);
-	}
+	PEV_INITIALIZE();
 
 	if (argc < 2) {
 		usage();
 		exit(EXIT_FAILURE);
 	}
 
-	output_init(); // Requires plugin for text output.
 	output_set_cmdline(argc, argv);
 
 	options_t *options = parse_options(argc, argv); // opcoes
@@ -470,9 +466,7 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-	output_term();
-
-	plugins_unload_all();
+	PEV_FINALIZE();
 
 	return EXIT_SUCCESS;
 }

--- a/src/pestr.c
+++ b/src/pestr.c
@@ -245,6 +245,8 @@ static void printb(
 
 int main(int argc, char *argv[])
 {
+	//PEV_INITIALIZE();
+
 	if (argc < 2) {
 		usage();
 		exit(EXIT_FAILURE);
@@ -327,6 +329,8 @@ int main(int argc, char *argv[])
 		pe_error_print(stderr, err);
 		return EXIT_FAILURE;
 	}
+
+	//PEV_FINALIZE();
 
 	return EXIT_SUCCESS;
 }

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -213,3 +213,23 @@ void plugins_unload_all(void) {
 		free(entry);
 	}
 }
+
+#include "compat/gnuc_attr_ctor_prios.h"
+
+#if defined(__GNUC__)
+__attribute__((constructor (ATTR_CTOR_PRIO_PLUGINS)))
+#endif
+static void initializer(void) {
+	//printf("plugins\n");
+	int ret = plugins_load_all();
+	if (ret < 0)
+		exit(EXIT_FAILURE);
+}
+
+#if defined(__GNUC__)
+__attribute__((destructor (ATTR_CTOR_PRIO_PLUGINS)))
+#endif
+static void finalizer(void) {
+	//printf("~plugins\n");
+	plugins_unload_all();
+}

--- a/src/readpe.c
+++ b/src/readpe.c
@@ -910,17 +910,13 @@ static void print_imports(pe_ctx_t *ctx)
 
 int main(int argc, char *argv[])
 {
-	int ret = plugins_load_all();
-	if (ret < 0) {
-		exit(EXIT_FAILURE);
-	}
+	PEV_INITIALIZE();
 
 	if (argc < 2) {
 		usage();
 		return EXIT_FAILURE;
 	}
 
-	output_init();
 	output_set_cmdline(argc, argv);
 
 	parse_options(argc, argv); // Opcoes
@@ -1005,9 +1001,7 @@ int main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-	output_term();
-
-	plugins_unload_all();
+	PEV_FINALIZE();
 
 	return EXIT_SUCCESS;
 }

--- a/src/rva2ofs.c
+++ b/src/rva2ofs.c
@@ -69,6 +69,8 @@ static void parse_options(int argc, char *argv[])
 
 int main(int argc, char *argv[])
 {
+	//PEV_INITIALIZE();
+
 	if (argc != 3) {
 		usage();
 		return EXIT_FAILURE;
@@ -102,6 +104,8 @@ int main(int argc, char *argv[])
 
 	// libera a memoria
 	pe_unload(&ctx);
+
+	//PEV_FINALIZE();
 
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
IMPORTANT: Needs testing on Linux and Cygwin, both with GCC and Clang. Anyone? ;-)

Attempt to automatically load plugins and initialize subsystems.
It also takes care of unloading and deinitialization.

This mechanism relies on `__attribute__((constructor (priority)))`
which is a GCC extension and is also supported by Clang.

If you're not using GCC nor Clang, it falls back to the following
two macros that must be invoked manually under any circumstances:

```
PEV_INITIALIZE();   // Must be invoked before anything else.
PEV_FINALIZE();     // Must be invoked right before exiting.
```

These will do absolutely nothing if the automatic mechanism is
supported.

Note for Clang users: 

It does not respect priorities - at least on Darwin - but it does
respect the linking order, so that became an important thing now.
