### PR TITLE
Fix compilation with -Wl,--as-needed

### DIFF
--- a/lib/libpe/Makefile
+++ b/lib/libpe/Makefile
@@ -55,7 +55,7 @@ override CFLAGS += \
 	-W -Wall -Wextra -pedantic -std=c99 -c
 override CPPFLAGS += -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
 #override LDFLAGS += -lssl -lcrypto
-LIBS = -lssl -lcrypto
+LIBS = -lssl -lcrypto -lm
 
 # --- FIX: -fPIC is necessary to ALL shared objects! Changed above.
 #ifneq ($(PLATFORM_OS), CYGWIN)


### PR DESCRIPTION
pescan does not actually use the math library itself but libpe does.
This causes no issues as when libpe wants to use the math library it is already loaded by pescan.

Compiling with `-Wl,--as-needed` filters out unneeded linking and since the math library is not needed in pescan and not linked into libpe it will be removed. Thus throwing a missing symbol `_[mangaled stuff]_log2`.

This can easily be manually fixed on older versions by adding `-lm` to `LDFLAGS`.
So for example `LDFLAGS="${LDFLAGS} -Wl,--as-needed -lm" make`