### PR TITLE
Show CFG status on pesec

### DIFF
--- a/src/pesec.c
+++ b/src/pesec.c
@@ -496,6 +496,10 @@ int main(int argc, char *argv[])
 	snprintf(field, MAX_MSG, "SEH");
 	output(field, (dllchar & 0x400) ? "no" : "yes");
 
+	// cfg
+	snprintf(field, MAX_MSG, "CFG");
+	output(field, (dllchar & 0x4000) ? "yes" : "no");
+
 	// stack cookies
 	snprintf(field, MAX_MSG, "Stack cookies (EXPERIMENTAL)");
 	output(field, stack_cookies(&ctx) ? "yes" : "no");


### PR DESCRIPTION
> When the /guard:cf Control Flow Guard (CFG) option is specified, the compiler and linker insert extra runtime security checks to detect attempts to compromise your code.

https://learn.microsoft.com/en-us/cpp/build/reference/guard-enable-control-flow-guard?view=msvc-170
https://learn.microsoft.com/en-us/windows/win32/secbp/control-flow-guard
https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#dll-characteristics