### PR TITLE
fix 8 character long section names being cut off

### DIFF
--- a/lib/libpe/pe.c
+++ b/lib/libpe/pe.c
@@ -434,7 +434,7 @@ const char *pe_section_name(const pe_ctx_t *ctx, const IMAGE_SECTION_HEADER *sec
 	assert(ctx != NULL); // TODO we don't actually need *ctx here
 	assert(out_name_size >= SECTION_NAME_SIZE+1);
 	strncpy(out_name, (const char *)section_hdr->Name, SECTION_NAME_SIZE);
-	out_name[SECTION_NAME_SIZE-1] = '\0';
+	out_name[out_name_size-1] = '\0';
 	return out_name;
 }
 


### PR DESCRIPTION
Insert \0 on 9th+ character instead of the 8th.
The issue comes down to section names that are exactly 8 characters long do not have a terminating `\0`.
The code already added a `\0` but applied it always to the 8th character instead of the last character of the write buffer. (which needs to be 9 characters long).

fixes #195 