### PR TITLE
fix printing section names that are 8 bytes long

### DIFF
--- a/lib/libpe/pe.c
+++ b/lib/libpe/pe.c
@@ -504,7 +504,7 @@ const char *pe_section_name(const pe_ctx_t *ctx, const IMAGE_SECTION_HEADER *sec
 	assert(ctx != NULL);
 	assert(out_name_size >= SECTION_NAME_SIZE+1);
 	strncpy(out_name, (const char *)section_hdr->Name, SECTION_NAME_SIZE);
-	out_name[SECTION_NAME_SIZE-1] = '\0';
+	out_name[SECTION_NAME_SIZE] = '\0';
 	if (out_name[0] == '/' && out_name[1] >= '0' && out_name[1] <= '9' && ctx->pe.strings_ptr) {
 		char *endptr = NULL;
 		long int offset = -1;


### PR DESCRIPTION
pe_section_name accidentally replaces the last character in section names that are 8 bytes long with a NUL. This results in a section header name like `.cmdline`[1] being printed as `.cmdlin`.

This addresses the off-by-one issue by ensuring we have a NUL at the end of our buffer (which is >= 9 bytes) instead putting it at the byte before the end.

[1]: https://uapi-group.org/specifications/specs/unified_kernel_image/