### PR TITLE
Remove _FORTIFY_SOURCE definitions

### DIFF
--- a/lib/libpe/Makefile
+++ b/lib/libpe/Makefile
@@ -53,7 +53,7 @@ override CFLAGS += \
 	-I"./include" \
 	-fPIC \
 	-W -Wall -Wextra -pedantic -std=c99 -c
-override CPPFLAGS += -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
+
 #override LDFLAGS += -lssl -lcrypto
 LIBS = -lssl -lcrypto -lm
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -61,13 +61,6 @@ override CPPFLAGS += \
 	-DSHAREDIR="\"$(SHAREDIR)"\" \
 	-DPLUGINSDIR="\"$(pluginsdir)"\"
 
-# Some gcc/clang builds (depends on the distro) already define _FORTIFY_SOURCE internally, so we
-# only define it if it has not been already. This avoids redefinition warnings and weakening
-# those distros' hardening settings.
-ifneq ($(findstring _FORTIFY_SOURCE, $(CPPFLAGS)), _FORTIFY_SOURCE)
-        override CPPFLAGS += -D_FORTIFY_SOURCE=1
-endif
-
 ifeq ($(PLATFORM_OS), Darwin)
 	# We disable warnings for deprecated declarations since Apple deprecated OpenSSL in Mac OS X 10.7
 	override CFLAGS += -Wno-deprecated-declarations


### PR DESCRIPTION
Fixes #205 

With this PR the `_FORTIFY_SOURCE` level will be left to be handled by the distros default from now on. The previous approach could potentially downgrade the `_FORTIFY_SOURCE` level, especially if the compiler was internally setting it (i.e., not via `CPPFLAGS`), leading to unintended security configurations.