### PR TITLE
Fix library install name and plugin type on macOS

### DIFF
--- a/lib/libpe/Makefile
+++ b/lib/libpe/Makefile
@@ -106,7 +106,7 @@ else ifeq ($(PLATFORM_OS), GNU/kFreeBSD)
 	$(LINK) -shared -Wl,-soname,$(LIBNAME).so.1 $(LDFLAGS) -o $(LIBNAME).so $^ $(LIBS)
 else ifeq ($(PLATFORM_OS), Darwin)
 	$(LINK) -headerpad_max_install_names -dynamiclib \
-		-flat_namespace -install_name $(LIBNAME).$(VERSION).dylib \
+		-flat_namespace -install_name $(libdir)/$(LIBNAME).$(VERSION).dylib \
 		-current_version $(VERSION) -compatibility_version $(VERSION) \
 		$(LDFLAGS) -o $(LIBNAME).dylib $^ $(LIBS)
 else ifeq ($(PLATFORM_OS), CYGWIN)

--- a/src/plugins/Makefile
+++ b/src/plugins/Makefile
@@ -68,10 +68,8 @@ else ifeq ($(PLATFORM_OS), GNU)
 else ifeq ($(PLATFORM_OS), GNU/kFreeBSD)
 	$(LINK) -shared -Wl,-soname,$(LIBNAME).so.1 $(LDFLAGS) -o ${plugins_BUILDDIR}/$(LIBNAME).so $^
 else ifeq ($(PLATFORM_OS), Darwin)
-	$(LINK) -headerpad_max_install_names -dynamiclib \
+	$(LINK) -headerpad_max_install_names -bundle \
 		-undefined dynamic_lookup -fno-common \
-		-install_name $(LIBNAME).$(VERSION).dylib \
-		-current_version $(VERSION) -compatibility_version $(VERSION) \
 		$(LDFLAGS) -o ${plugins_BUILDDIR}/$(LIBNAME).dylib $^
 else ifeq ($(PLATFORM_OS), CYGWIN)
 	$(LINK) -shared $(LDFLAGS) -o ${plugins_BUILDDIR}/$(LIBNAME).dll $^


### PR DESCRIPTION
macOS requires an absolute path in the install name. Also, use `-bundle` for plugins which is preferred for loadable modules.