### PR TITLE
Update build instructions on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 LIBPE_DIR = lib/libpe
 PEV_DIR = src
 VERSION = 0.84
-ZIPDIR = pev-$(VERSION)-win
+ZIPDIR = readpe-$(VERSION)-win
 ZIPFILE = $(ZIPDIR).zip
 
 all:
@@ -18,7 +18,7 @@ zip:
 	cp $(PEV_DIR)/userdb.txt $(ZIPDIR)
 	cp lib/libpe/libpe.dll $(ZIPDIR)/
 	cp /usr/bin/cygwin1.dll $(ZIPDIR)/
-	cp /usr/bin/cygcrypto-1*.dll $(ZIPDIR)/
+	cp /usr/bin/cygcrypto-3.dll $(ZIPDIR)/
 	cp /usr/bin/cygz.dll $(ZIPDIR)/
 	cp README.md $(ZIPDIR)/
 	cp $(PEV_DIR)/build/*.exe $(ZIPDIR)/

--- a/README.md
+++ b/README.md
@@ -42,12 +42,14 @@ and analyze PE (Portable Executables) binaries.
 
 **NOTE**: The following packages must be installed along with your Cygwin:
 
-- gcc-core
-- binutils
-- make
-- zip
-- openssl-devel
-- git (just to clone the repository and make things easier)
+| Category | Package       |
+|----------|---------------|
+| Archive  | zip           |
+| Devel    | binutils      |
+| Devel    | gcc-core      |
+| Devel    | git           |
+| Devel    | make          |
+| Net      | libssl-devel  |
 
 ## FAQ
 


### PR DESCRIPTION
Cygwin updated a library and this broke the Makefile. This PR fixes it and updates the README file accordingly.