### PR TITLE
Fix hashing not terminating C strings

### DIFF
--- a/lib/libpe/hashes.c
+++ b/lib/libpe/hashes.c
@@ -186,6 +186,7 @@ static void to_hex_str(const uint8_t* input, char* output, size_t n)
 		*output++ = "0123456789abcdef"[b >> 4];
 		*output++ = "0123456789abcdef"[b & 0xf];
 	}
+	*output = '\0';
 }
 
 bool pe_hash_raw_data(char *output, size_t output_size, const char *alg_name, const unsigned char *data, size_t data_size) {

--- a/src/pehash.c
+++ b/src/pehash.c
@@ -182,6 +182,7 @@ static void print_basic_hash(const unsigned char *data, size_t data_size)
     char *hash_value = malloc_s(hash_value_size);
 
     for (size_t i=0; i < sizeof(basic_hashes) / sizeof(char *); i++) {
+		memset(hash_value, 0, hash_value_size);
         pe_hash_raw_data(hash_value, hash_value_size, basic_hashes[i], data, data_size);
         output(basic_hashes[i], hash_value);
     }


### PR DESCRIPTION
This fix applies to both the output in pehash.c
as also the string generation in hashes.c

This fixes #224