### PR TITLE
Fix recognizing ordinal-only imported functions with zero type

### DIFF
--- a/.github/workflows/multi-os-build.yml
+++ b/.github/workflows/multi-os-build.yml
@@ -41,7 +41,7 @@ jobs:
         submodules: 'true'
 
     - name: Compile
-      run: CFLAGS="-I$(brew --prefix openssl@1.1)/include/" LDFLAGS="-L$(brew --prefix openssl@1.1)/lib/" make
+      run: CFLAGS="-I$(brew --prefix openssl@3)/include/" LDFLAGS="-L$(brew --prefix openssl@3)/lib/" make
       
   build-win64:
 

--- a/lib/libpe/include/libpe/pe.h
+++ b/lib/libpe/include/libpe/pe.h
@@ -58,7 +58,7 @@ extern "C" {
 static const uint32_t IMAGE_ORDINAL_FLAG32 = 0x80000000;
 static const uint64_t IMAGE_ORDINAL_FLAG64 = 0x8000000000000000;
 #define IMAGE_ORDINAL_MASK(ctx) \
-  ((ctx->pe.optional_hdr.type == MAGIC_PE32) ? \
+  ((ctx->pe.optional_hdr.type == MAGIC_PE32_0 || ctx->pe.optional_hdr.type == MAGIC_PE32) ? \
    IMAGE_ORDINAL_FLAG32 : IMAGE_ORDINAL_FLAG64)
 
 #define SIGNATURE_PE 0x00004550 // PE\0\0 in little-endian


### PR DESCRIPTION
Fix recognizing ordinal-only imported functions in PE32 binaries with zero type

This change fixes the commit a430968fbc1a ("Recognize PE32 binaries with zero type of optional header") as there is one extra place where check for MAGIC_PE32_0 is missing.

For example fixes recognizing of ordinal imports in Win32s LZ32.DLL library.